### PR TITLE
add Configuration for Symfony Console

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ settings.json
         "strings": true
     }
 ```
+### Symfony Console Run All Symfony Commands
+change the console path
+
+settings.json
+```json
+    "superConsole.path": "your console path default is php bin/console"
+```
 
 ## Changelog
 See the [changelog](https://github.com/DuboisS/vscode-sf-pack/blob/master/CHANGELOG.md) for releases notes.


### PR DESCRIPTION
The new version of **Symfony Console Run All Symfony Commands** has very useful setting called _superConsole.path_, with this setting you can set your console path so if you are working with docker you can use this Extension without any problem.